### PR TITLE
[WSP-3359] Feature/job status check

### DIFF
--- a/spec/wrapFetch.spec.coffee
+++ b/spec/wrapFetch.spec.coffee
@@ -1,12 +1,126 @@
 require('isomorphic-fetch')
 fetchMock = require('fetch-mock')
 wrapFetch = require('../src/wrapFetch')
-
-BASE_URL = 'wrapFetchs://api.wrap.co/api'
+BASE_URL = require('./helpers').BASE_URL
 
 describe('wrapFetch', ->
-	afterEach(->
-		fetchMock.restore()
+	afterEach(fetchMock.restore)
+
+	describe('response bodies', ->
+		describe('with a JSON content type', ->
+			it('should resolve a valid JSON body', (done) ->
+				validJson = '{ "hello": "world" }'
+
+				fetchMock.mock(BASE_URL, {
+					headers: { 'content-type': 'application/json' }
+					body: validJson
+				})
+
+				wrapFetch.get(BASE_URL)
+					.then((parsedBody) ->
+						expect(parsedBody).toEqual({ hello: 'world' })
+						done()
+					)
+			)
+
+			it('should reject an invalid JSON body', (done) ->
+				invalidJson = ''
+
+				fetchMock.mock(BASE_URL, {
+					headers: { 'content-type': 'application/json' }
+					body: invalidJson
+				})
+
+				wrapFetch.get(BASE_URL)
+					.catch((error) ->
+						expect(error.name).toBe('SyntaxError')
+						done()
+					)
+			)
+		)
+
+		describe('with a text content type', ->
+			it('should resolve the response body', (done) ->
+				fetchMock.mock(BASE_URL, {
+					headers: { 'content-type': 'text/html' }
+					body: '<p>hello</p>'
+				})
+
+				wrapFetch.get(BASE_URL)
+					.then((parsedBody) ->
+						expect(parsedBody).toEqual('<p>hello</p>')
+						done()
+					)
+			)
+		)
+
+		describe('with any other content type', ->
+			it('should resolve undefined', (done) ->
+				fetchMock.mock(BASE_URL, {
+					headers: { 'content-type': 'image/jpeg' }
+				})
+
+				wrapFetch.get(BASE_URL)
+					.then((parsedBody) ->
+						expect(parsedBody).toBe(undefined)
+						done()
+					)
+			)
+		)
+	)
+
+	describe('202 responses', ->
+		beforeEach(->
+			fetchMock.mock(BASE_URL + '/wraps/123/publish', 'POST', {
+				status: 202
+				headers: { 'content-type': 'application/json' }
+				body: { status_url: BASE_URL + '/jobs?token=456' }
+			})
+		)
+
+		it('should query the returned job status URL', (done) ->
+			fetchMock.mock(BASE_URL + '/jobs?token=456', 200)
+
+			wrapFetch.post(BASE_URL + '/wraps/123/publish')
+				.then(->
+					expect(fetchMock.called(BASE_URL + '/jobs?token=456')).toBe(true)
+					done()
+				)
+		)
+	)
+
+	describe('responses with non 2xx status codes', ->
+		beforeEach(->
+			responseBody = { status: 404, message: 'Not Found' }
+
+			fetchMock.mock(BASE_URL + '/wraps/123', 'GET', {
+				status: 404
+				headers: { 'content-type': 'application/json' }
+				body: responseBody
+			})
+		)
+
+		it('should not resolve', (done) ->
+			wrapFetch.get(BASE_URL + '/wraps/123')
+				.then(-> done.fail('Promise should not be resolved'))
+				.catch((error) -> done())
+		)
+
+		it('should be rejected with the response status text as the error message', (done) ->
+			wrapFetch.get(BASE_URL + '/wraps/123')
+				.catch((error) ->
+					expect(error.message).toBe('Not Found')
+					done()
+				)
+		)
+
+		it('should be rejected with the response body as error.response', (done) ->
+			wrapFetch.get(BASE_URL + '/wraps/123')
+				.catch((error) ->
+					expect(error.response).toEqual({ status: 404, message: 'Not Found' })
+					done()
+				)
+		)
 	)
 
 	describe('GET requests', ->
@@ -16,31 +130,6 @@ describe('wrapFetch', ->
 			wrapFetch.get(BASE_URL + '/wraps', { search: { page: 1, page_size: 20 } })
 				.then(->
 					expect(fetchMock.called(BASE_URL + '/wraps?page=1&page_size=20')).toBe(true)
-					done()
-				)
-		)
-	)
-
-	describe('responses with non 2xx status codes', ->
-		beforeEach(->
-			fetchMock.mock(BASE_URL + '/wraps/009DF38D-4000-4353-9D25-0E4099418FEC', 'GET', {
-				status: 404
-				headers: { 'content-type': 'application/json' }
-				body: {}
-				throws: { message: 'Not Found' }
-			})
-		)
-
-		it('should not resolve', (done) ->
-			wrapFetch.get(BASE_URL + '/wraps/009DF38D-4000-4353-9D25-0E4099418FEC')
-				.then(-> done.fail('Promise should not be resolved'))
-				.catch((error) -> done())
-		)
-
-		it('should be rejected with the response status text as the error message', (done) ->
-			wrapFetch.get(BASE_URL + '/wraps/009DF38D-4000-4353-9D25-0E4099418FEC')
-				.catch((error) ->
-					expect(error.message).toBe('Not Found')
 					done()
 				)
 		)

--- a/spec/wrapFetch.spec.coffee
+++ b/spec/wrapFetch.spec.coffee
@@ -72,10 +72,10 @@ describe('wrapFetch', ->
 
 	describe('202 responses', ->
 		beforeEach(->
-			fetchMock.mock(BASE_URL + '/wraps/123/publish', 'POST', {
+			fetchMock.mock("#{BASE_URL}/wraps/123/publish", 'POST', {
 				status: 202
 				headers: { 'content-type': MIME_TYPE.JSON }
-				body: { status_url: BASE_URL + '/jobs?token=456' }
+				body: { status_url: "#{BASE_URL}/jobs?token=456" }
 			})
 		)
 
@@ -95,7 +95,7 @@ describe('wrapFetch', ->
 				body: { published: true }
 			}
 
-			fetchMock.mock(BASE_URL + '/jobs?token=456', (url, opts) ->
+			fetchMock.mock("#{BASE_URL}/jobs?token=456", (url, opts) ->
 				currentStatusRequest++
 
 				if currentStatusRequest == maxStatusRequest
@@ -104,9 +104,9 @@ describe('wrapFetch', ->
 					return acceptedResponse
 			)
 
-			wrapFetch.post(BASE_URL + '/wraps/123/publish')
+			wrapFetch.post("#{BASE_URL}/wraps/123/publish")
 				.then((parsedBody) ->
-					expect(fetchMock.called(BASE_URL + '/jobs?token=456')).toBe(true)
+					expect(fetchMock.called("#{BASE_URL}/jobs?token=456")).toBe(true)
 					done()
 				)
 		)
@@ -114,7 +114,7 @@ describe('wrapFetch', ->
 
 	describe('responses with non 2xx status codes', ->
 		beforeEach(->
-			fetchMock.mock(BASE_URL + '/wraps/123', 'GET', {
+			fetchMock.mock("#{BASE_URL}/wraps/123", 'GET', {
 				status: 404
 				headers: { 'content-type': MIME_TYPE.JSON }
 				body: { status: 404, message: 'Not Found' }
@@ -122,13 +122,13 @@ describe('wrapFetch', ->
 		)
 
 		it('should not resolve', (done) ->
-			wrapFetch.get(BASE_URL + '/wraps/123')
+			wrapFetch.get("#{BASE_URL}/wraps/123")
 				.then(-> done.fail('Promise should not be resolved'))
 				.catch((error) -> done())
 		)
 
 		it('should be rejected with the response status text as the error message', (done) ->
-			wrapFetch.get(BASE_URL + '/wraps/123')
+			wrapFetch.get("#{BASE_URL}/wraps/123")
 				.catch((error) ->
 					expect(error.message).toBe('Not Found')
 					done()
@@ -136,7 +136,7 @@ describe('wrapFetch', ->
 		)
 
 		it('should be rejected with the response body as error.response', (done) ->
-			wrapFetch.get(BASE_URL + '/wraps/123')
+			wrapFetch.get("#{BASE_URL}/wraps/123")
 				.catch((error) ->
 					expect(error.response).toEqual({ status: 404, message: 'Not Found' })
 					done()
@@ -146,11 +146,11 @@ describe('wrapFetch', ->
 
 	describe('GET requests', ->
 		it('should include a query string when a search hash is provided', (done) ->
-			fetchMock.mock(BASE_URL + '/wraps?page=1&page_size=20', 'GET', [])
+			fetchMock.mock("#{BASE_URL}/wraps?page=1&page_size=20", 'GET', [])
 
 			wrapFetch.get(BASE_URL + '/wraps', { search: { page: 1, page_size: 20 } })
 				.then(->
-					expect(fetchMock.called(BASE_URL + '/wraps?page=1&page_size=20')).toBe(true)
+					expect(fetchMock.called("#{BASE_URL}/wraps?page=1&page_size=20")).toBe(true)
 					done()
 				)
 		)

--- a/src/WrapResource.coffee
+++ b/src/WrapResource.coffee
@@ -23,8 +23,6 @@ WrapResource.createEndpoint = ({ method = HTTP.GET, path = '', urlParams = [] })
 
 		options = { headers: @_getAuthHeader() }
 
-		options.baseUrl = @_client.baseUrl
-
 		body = args.shift()
 		if isObject(body)
 			if method == HTTP.GET

--- a/src/constants.coffee
+++ b/src/constants.coffee
@@ -1,5 +1,5 @@
 constants = {
-	PRODUCTION_API_URL: 'https://api.wrap.co/api'
+	PRODUCTION_API_URL: 'http://localhost:55417/api'
 	HTTP_METHODS: {
 		GET: 'GET'
 		POST: 'POST'
@@ -10,6 +10,11 @@ constants = {
 	MESSAGE_SERVICES: {
 		SMS: 'sms'
 		MMS: 'mms'
+	}
+	MIME_TYPES: {
+		JSON: 'application/json'
+		HTML: 'text/html'
+		TEXT: 'text/plain'
 	}
 }
 


### PR DESCRIPTION
Fixed the broken job status polling. Went ahead and updated the polling to use the status url returned in the initial response. Refactored body parsing to better handle JSON and text content types. JSON parsing errors now cause promise rejections.

@WrapMedia/javascript 
